### PR TITLE
bypass IPs not in AllowedIPs

### DIFF
--- a/proxy_protocol_test.go
+++ b/proxy_protocol_test.go
@@ -324,6 +324,8 @@ func (ts ProxyProtocolTestSuite) TestProxyProtocolListenerProxyNotAllowed(c *C) 
 
 		conn, err := ppl.Accept()
 		c.Assert(err, IsNil)
+		time.Sleep(2 * time.Second)
+		conn.Close()
 	}()
 
 	conn, err := net.Dial("tcp", addr)

--- a/proxy_protocol_test.go
+++ b/proxy_protocol_test.go
@@ -323,8 +323,7 @@ func (ts ProxyProtocolTestSuite) TestProxyProtocolListenerProxyNotAllowed(c *C) 
 		defer ppl.Close()
 
 		conn, err := ppl.Accept()
-		c.Assert(conn, IsNil)
-		c.Assert(err, Equals, ErrProxyAddressNotAllowed)
+		c.Assert(err, IsNil)
 	}()
 
 	conn, err := net.Dial("tcp", addr)


### PR DESCRIPTION
Most proxy protocol implementions, such as MariaDB and Percona Server
forces IP in AllowedIPs to use proxy protocol, and forces IP not in
AllowdIPs to not use proxy protocol. They still accept IPs not in
AllowdIPs to connect. They just won't parse proxy protocol header.

I think that's a more user friendly way.

I have read proxy protocol spec:

> The receiver SHOULD ensure proper access filtering so that only
> trusted proxyies are allowd to use this protocol.

We meet the spec requirement because we do not allow untrusted proxyies
to use proxy protocol. They are forced to use normal protocol.